### PR TITLE
Feature/build for free dev account

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,13 +1,13 @@
 
 [submodule "submodules/rlottie/rlottie"]
 	path = submodules/rlottie/rlottie
-	url=../rlottie.git
+	url = https://github.com/TelegramMessenger/rlottie.git
 [submodule "build-system/bazel-rules/rules_apple"]
 	path = build-system/bazel-rules/rules_apple
-url=https://github.com/bazelbuild/rules_apple.git
+	url=https://github.com/bazelbuild/rules_apple.git
 [submodule "build-system/bazel-rules/rules_swift"]
 	path = build-system/bazel-rules/rules_swift
-url=https://github.com/ali-fareed/rules_swift.git
+	url=https://github.com/ali-fareed/rules_swift.git
 [submodule "build-system/bazel-rules/apple_support"]
 	path = build-system/bazel-rules/apple_support
 	url = https://github.com/bazelbuild/apple_support.git
@@ -16,10 +16,10 @@ url=https://github.com/ali-fareed/rules_swift.git
 	url = https://github.com/telegramdesktop/libtgvoip.git
 [submodule "build-system/tulsi"]
 	path = build-system/tulsi
-url=https://github.com/ali-fareed/tulsi.git
+	url=https://github.com/ali-fareed/tulsi.git
 [submodule "submodules/TgVoipWebrtc/tgcalls"]
 	path = submodules/TgVoipWebrtc/tgcalls
-url=../tgcalls.git
+	url = https://github.com/TelegramMessenger/tgcalls.git
 [submodule "third-party/libvpx/libvpx"]
 	path = third-party/libvpx/libvpx
 	url = https://github.com/webmproject/libvpx.git

--- a/README.md
+++ b/README.md
@@ -106,3 +106,21 @@ Each release is built using specific Xcode and Bazel versions (see `versions.jso
 python3 build-system/Make/Make.py --overrideBazelVersion build ... # Don't check the version of Bazel
 python3 build-system/Make/Make.py --overrideXcodeVersion build ... # Don't check the version of Xcode
 ```
+
+# Build without developer account
+
+In case if you have no Developer account you still can build Telegram with your Apple ID.
+
+The steps are the same but ake sure that your specificed those properties in your `variables.bzl`:
+ - `telegram_bundle_id` - any free bundle_id
+ - `telegram_api_id` - can be obtained from https://my.telegram.org/apps
+ - `telegram_api_hash` - can be obtained from https://my.telegram.org/apps
+ - `telegram_team_id` - can be obtained from https://developer.apple.com/account/#!/membership
+ - `telegram_app_center_id = "0"`
+ - `telegram_is_internal_build = "true"`
+ - `telegram_is_appstore_build = "false"`
+ - `telegram_is_non_dev_account = True`
+ - `telegram_aps_environment = ""`
+ - `telegram_enable_siri = False`
+ - `telegram_enable_icloud = False`
+ - `telegram_enable_watch = False`

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ python3 build-system/Make/Make.py --overrideXcodeVersion build ... # Don't check
 
 In case if you have no Developer account you still can build Telegram with your Apple ID.
 
-The steps are the same but ake sure that your specificed those properties in your `variables.bzl`:
+The steps are the same but be sure that you specify those properties in your `variables.bzl`:
  - `telegram_bundle_id` - any free bundle_id
  - `telegram_api_id` - can be obtained from https://my.telegram.org/apps
  - `telegram_api_hash` - can be obtained from https://my.telegram.org/apps

--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -35,6 +35,7 @@ load(
     "telegram_enable_icloud",
     "telegram_enable_siri",
     "telegram_enable_watch",
+    "telegram_is_non_dev_account",
 )
 
 load("@build_bazel_rules_apple//apple:resources.bzl",
@@ -450,11 +451,16 @@ aps_fragment = "" if telegram_aps_environment == "" else """
 <string>{telegram_aps_environment}</string>
 """.format(telegram_aps_environment=telegram_aps_environment)
 
-app_groups_fragment = """
+app_groups_fragment = "" if telegram_is_non_dev_account else """
     <key>com.apple.security.application-groups</key>
     <array>
         <string>group.{telegram_bundle_id}</string>
     </array>
+""".format(
+    telegram_bundle_id=telegram_bundle_id
+)
+
+app_id_fragment = """
     <key>application-identifier</key>
     <string>{telegram_team_id}.{telegram_bundle_id}</string>
 """.format(
@@ -462,7 +468,7 @@ app_groups_fragment = """
     telegram_bundle_id=telegram_bundle_id
 )
 
-communication_notifications_fragment = """
+communication_notifications_fragment = "" if telegram_is_non_dev_account else """
 <key>com.apple.developer.usernotifications.communication</key>
 <true/>
 """
@@ -473,6 +479,7 @@ plist_fragment(
     template = "".join([
         aps_fragment,
         app_groups_fragment,
+        app_id_fragment,
         siri_fragment,
         associated_domains_fragment,
         icloud_fragment,

--- a/build-system/example-configuration/variables.bzl
+++ b/build-system/example-configuration/variables.bzl
@@ -6,6 +6,7 @@ telegram_team_id = "C67CF9S4VU"
 telegram_app_center_id = "0"
 telegram_is_internal_build = "false"
 telegram_is_appstore_build = "true"
+telegram_is_non_dev_account = False
 telegram_appstore_id = "686449807"
 telegram_app_specific_url_scheme = "tg"
 telegram_aps_environment = "production"

--- a/submodules/BuildConfig/BUILD
+++ b/submodules/BuildConfig/BUILD
@@ -5,6 +5,7 @@ load(
     "telegram_app_center_id",
     "telegram_is_internal_build",
     "telegram_is_appstore_build",
+    "telegram_is_non_dev_account",
     "telegram_appstore_id",
     "telegram_app_specific_url_scheme",
 )
@@ -23,6 +24,7 @@ objc_library(
         "-DAPP_CONFIG_APP_CENTER_ID=\\\"{}\\\"".format(telegram_app_center_id),
         "-DAPP_CONFIG_IS_INTERNAL_BUILD={}".format(telegram_is_internal_build),
         "-DAPP_CONFIG_IS_APPSTORE_BUILD={}".format(telegram_is_appstore_build),
+        "-DAPP_CONFIG_NO_DEV_ACCOUNT={}".format("true" if telegram_is_non_dev_account else "false"),
         "-DAPP_CONFIG_APPSTORE_ID={}".format(telegram_appstore_id),
         "-DAPP_SPECIFIC_URL_SCHEME=\\\"{}\\\"".format(telegram_app_specific_url_scheme),
     ],

--- a/submodules/BuildConfig/PublicHeaders/BuildConfig/BuildConfig.h
+++ b/submodules/BuildConfig/PublicHeaders/BuildConfig/BuildConfig.h
@@ -26,4 +26,6 @@
 + (void)encryptApplicationSecret:(NSData * _Nonnull)secret baseAppBundleId:(NSString * _Nonnull)baseAppBundleId completion:(void (^ _Nonnull)(NSData * _Nullable, NSData * _Nullable))completion;
 + (void)decryptApplicationSecret:(NSData * _Nonnull)secret publicKey:(NSData * _Nonnull)publicKey baseAppBundleId:(NSString * _Nonnull)baseAppBundleId completion:(void (^ _Nonnull)(NSData * _Nullable, bool))completion;
 
++ (bool) isNonDevAccount;
+
 @end

--- a/submodules/BuildConfig/Sources/BuildConfig.m
+++ b/submodules/BuildConfig/Sources/BuildConfig.m
@@ -484,4 +484,8 @@ API_AVAILABLE(ios(10))
     });
 }
 
++ (bool)isNonDevAccount {
+    return APP_CONFIG_NO_DEV_ACCOUNT;
+}
+
 @end

--- a/submodules/CloudData/BUILD
+++ b/submodules/CloudData/BUILD
@@ -13,6 +13,7 @@ swift_library(
         "//submodules/SSignalKit/SwiftSignalKit:SwiftSignalKit",
         "//submodules/MtProtoKit:MtProtoKit",
         "//submodules/EncryptionProvider:EncryptionProvider",
+        "//submodules/BuildConfig:BuildConfig",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/CloudData/Sources/CloudData.swift
+++ b/submodules/CloudData/Sources/CloudData.swift
@@ -3,6 +3,7 @@ import CloudKit
 import MtProtoKit
 import SwiftSignalKit
 import EncryptionProvider
+import BuildConfig
 
 private enum FetchError {
     case generic
@@ -15,6 +16,9 @@ private func fetchRawData(prefix: String) -> Signal<Data, FetchError> {
         #if targetEnvironment(simulator)
         return EmptyDisposable
         #else
+        if BuildConfig.isNonDevAccount() {
+            return EmptyDisposable
+        }
         let container = CKContainer.default()
         let publicDatabase = container.database(with: .public)
         let recordId = CKRecord.ID(recordName: "emergency-datacenter-\(prefix)")

--- a/submodules/TelegramUI/Sources/AppDelegate.swift
+++ b/submodules/TelegramUI/Sources/AppDelegate.swift
@@ -443,10 +443,17 @@ private func extractAccountManagerState(records: AccountRecordsView<TelegramAcco
             }
             return data
         }, autolockDeadine: autolockDeadine, encryptionProvider: OpenSSLEncryptionProvider(), resolvedDeviceName: nil)
-        
-        guard let appGroupUrl = maybeAppGroupUrl else {
-            self.mainWindow?.presentNative(UIAlertController(title: nil, message: "Error 2", preferredStyle: .alert))
-            return true
+
+        var appGroupUrl: URL!
+        if maybeAppGroupUrl != nil {
+            appGroupUrl = maybeAppGroupUrl!
+        } else {
+            guard BuildConfig.isNonDevAccount(),
+                  let appDocUrl = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else {
+                self.mainWindow?.presentNative(UIAlertController(title: nil, message: "Error 2", preferredStyle: .alert))
+                return true
+            }
+            appGroupUrl = appDocUrl
         }
         
         var isDebugConfiguration = false
@@ -643,7 +650,7 @@ private func extractAccountManagerState(records: AccountRecordsView<TelegramAcco
                 completion(false)
             }
         }, siriAuthorization: {
-            if #available(iOS 10, *) {
+            if #available(iOS 10, *), !BuildConfig.isNonDevAccount() {
                 switch INPreferences.siriAuthorizationStatus() {
                     case .authorized:
                         return .allowed


### PR DESCRIPTION
### Problem

Originally iOS app can be built/deployed only by using developer account.
Some time ago Apple allow to compile apps with regular Apple ID, but not all entitlements are available for such developer, i.e. `com.apple.security.application-groups`, `com.apple.developer.usernotifications.communication` and some other aren't available

### Solution

This PR 'turn off' such entitlements in basel's BUILD files. And provide `BuildConfig.isNonDevAccount()` for runtime checks.

I did quick test (main, chat, settings), so runtime failures maybe still possible in other app parts

P.S. Also this PR fix relative links in `.gitmodules`